### PR TITLE
Reformat dashboard weekly summary layout

### DIFF
--- a/cms_index.html
+++ b/cms_index.html
@@ -29,10 +29,6 @@
         <!-- NAV: GIỮ id="menu" (JS cũ có thể gắn sự kiện vào đây) -->
         <nav id="menu" class="menu-vertical"></nav>
 
-        <div class="quick">
-          <button class="btn block" onclick="document.getElementById('dlg_customer').showModal()">+ Khách hàng</button>
-          <button class="btn block" onclick="document.getElementById('dlg_loan').showModal()">+ Hợp đồng</button>
-        </div>
       </aside>
 
       <main class="content">
@@ -101,7 +97,7 @@
             <button class="btn" onclick="loadDashboardWeekBlocks()">Áp dụng</button>
           </div>
 
-          <div class="grid-2">
+          <div class="dash-week-grid">
             <div class="card">
               <div class="card-head">Hợp đồng tạo trong tuần</div>
               <div class="card-body">

--- a/cms_styles.html
+++ b/cms_styles.html
@@ -144,8 +144,34 @@
     box-shadow:var(--shadow);
     padding:16px;
   }
+  .card-head{
+    font-weight:700;
+    font-size:14px;
+    color:#1f2937;
+  }
+  .card-head + .card-body{
+    margin-top:12px;
+  }
   .card-title{
     font-weight:700; margin-bottom:8px;
+  }
+  .dash-week-grid{
+    display:grid;
+    grid-template-columns:repeat(2, minmax(0, 1fr));
+    gap:16px;
+    margin-top:16px;
+  }
+  .dash-week-grid .card{
+    display:flex;
+    flex-direction:column;
+  }
+  .dash-week-grid .card-body{
+    flex:1;
+    display:flex;
+    flex-direction:column;
+  }
+  .dash-week-grid .card-body .tbl{
+    flex:1;
   }
   .two-col{
     display:grid; grid-template-columns:1fr 1fr; gap:16px;
@@ -262,6 +288,7 @@
   @media (max-width: 720px){
     .app{ grid-template-columns: 1fr; }
     #menu{ position:relative; top:auto; max-height:none; }
+    .dash-week-grid{ grid-template-columns:1fr; }
   }
 
   /* ================== ACCESSIBILITY ================== */


### PR DESCRIPTION
## Summary
- remove the quick action buttons for adding customers and contracts from the sidebar menu
- add dedicated styling to arrange the four weekly dashboard cards in a square grid layout
- keep the weekly cards responsive by stacking them vertically on small screens

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68df9b83dbb883299f8f1418f80ddf09