### PR TITLE
Fix login overlay interactions and appearance

### DIFF
--- a/cms_styles.html
+++ b/cms_styles.html
@@ -65,16 +65,15 @@
 
   .login-blocker{
     position:fixed;
-    inset:56px 0 0 0;
-    background:rgba(15,23,42,0.65);
+    inset:0;
+    background:#ffffff;
     display:flex;
     align-items:center;
     justify-content:center;
     z-index:120;
     padding:24px;
   }
-  body.needs-login .app{ pointer-events:none; }
-  body.needs-login #login_blocker{ pointer-events:auto; }
+  body.needs-login .app > :not(#login_blocker){ pointer-events:none; }
   .login-blocker.hidden{ display:none !important; }
   .login-blocker-card{
     max-width:360px;


### PR DESCRIPTION
## Summary
- ensure the login blocker covers the entire page with a neutral white background when authentication is required
- limit pointer events on the main layout while preserving interactivity for the login overlay so the sign-in buttons work again

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e00c59f7ec832994e827c087fd8f71