### PR TITLE
Fix login overlay to display credentials form

### DIFF
--- a/cms_login.html
+++ b/cms_login.html
@@ -1,4 +1,4 @@
-<dialog id="dlg_login" class="modal">
+<div id="dlg_login" class="modal modal-overlay">
   <div class="box">
     <div class="head">
       <div class="title">Đăng nhập tài khoản nội bộ</div>
@@ -17,8 +17,8 @@
       </div>
     </div>
     <div class="foot">
-      <button class="btn" type="button" onclick="document.getElementById('dlg_login').close()">Đóng</button>
+      <button class="btn" type="button" onclick="closeLoginDialog()">Đóng</button>
       <button class="btn primary" type="button" id="btn_login_do">Đăng nhập</button>
     </div>
   </div>
-</dialog>
+</div>

--- a/cms_scripts.html
+++ b/cms_scripts.html
@@ -53,10 +53,30 @@ function setAuthState(ok, meta){
 function showLoginDialog(){
   const dlg = document.getElementById('dlg_login');
   if (!dlg) return;
-  if (!dlg.open) dlg.showModal();
+  if (dlg.classList?.contains('modal-overlay')){
+    dlg.classList.add('show');
+  } else if (typeof dlg.showModal === 'function'){
+    if (!dlg.open) dlg.showModal();
+  } else {
+    dlg.setAttribute('open', 'true');
+    dlg.classList.add('show');
+  }
   const user = document.getElementById('login_user');
   if (user){
     setTimeout(()=>{ user.focus(); user.select(); }, 0);
+  }
+}
+
+function closeLoginDialog(){
+  const dlg = document.getElementById('dlg_login');
+  if (!dlg) return;
+  if (dlg.classList?.contains('modal-overlay')){
+    dlg.classList.remove('show');
+  } else if (typeof dlg.close === 'function'){
+    dlg.close();
+  } else {
+    dlg.removeAttribute('open');
+    dlg.classList.remove('show');
   }
 }
 
@@ -875,7 +895,7 @@ function handleLoginSuccess(res, fallbackUser){
   if (!res?.ok || !res.token) return false;
   setToken(res.token);
   setAuthState(true, res);
-  document.getElementById('dlg_login')?.close();
+  closeLoginDialog();
   applyMenuVisibility();
   onRoute();
   const name = res.display || fallbackUser || '';

--- a/cms_styles.html
+++ b/cms_styles.html
@@ -404,18 +404,27 @@
   }
 
   /* ================== MODAL ================== */
-  dialog.modal{
+  dialog.modal,
+  .modal-overlay{
     position:fixed; inset:0; z-index:200;
     display:none; align-items:center; justify-content:center;
     padding:16px;
     border:none;
     background:transparent;
   }
-  dialog.modal[open]{ display:flex; }
+  dialog.modal[open],
+  .modal-overlay.show{ display:flex; }
   dialog.modal::backdrop{
     background:rgba(17,24,39,.35);
   }
-  dialog.modal .box{
+  .modal-overlay::before{
+    content:"";
+    position:absolute; inset:0;
+    background:rgba(17,24,39,.35);
+  }
+  dialog.modal .box,
+  .modal-overlay .box{
+    position:relative;
     width:min(720px, 96vw);
     background:#fff;
     border-radius:16px;


### PR DESCRIPTION
## Summary
- replace the login <dialog> with a custom overlay so the username/password form renders reliably
- update shared modal styles and login scripts to toggle the new overlay and close helper

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0177ba36483298a2f0cf7d8f78135