### PR TITLE
Use session principal when saving records

### DIFF
--- a/cms_backend.js
+++ b/cms_backend.js
@@ -393,7 +393,7 @@ function listRecords(payload, page, q) {
 function saveRecord(payload) {
   var tbl = payload && payload.tableKey;
   var menuKey = _menuKeyForTable_(tbl);
-  mustHaveHybrid(payload, menuKey);
+  var ctx = mustHaveHybrid(payload, menuKey);
 
   payload = payload || {};
   var tableKey = payload.tableKey;
@@ -419,9 +419,10 @@ function saveRecord(payload) {
 
   var idVal = (record[idColName] || '').toString().trim();
 
-  var now = _now_(), me = _me_();
+  var now = _now_();
+  var actor = (ctx && ctx.principal) || (ctx && ctx.display) || _me_();
   if (hmap['Cập nhật']  !== undefined) rowArr[hmap['Cập nhật']]  = now;
-  if (hmap['Người sửa'] !== undefined) rowArr[hmap['Người sửa']] = me;
+  if (hmap['Người sửa'] !== undefined) rowArr[hmap['Người sửa']] = actor;
 
   if (!idVal) {
     var prefix = (tableKey === 'CUSTOMERS') ? 'VC' :


### PR DESCRIPTION
## Summary
- capture the hybrid session context when saving CMS records
- prefer the authenticated session principal/display for the "Người sửa" column before falling back to the Apps Script user

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e0a22dde18832990cd0684a6c70c05