### PR TITLE
Add config admin login and dashboard customization

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -845,7 +845,7 @@
       }, showErr);
     }
 
-    const SESS_KEY = 'WQT_SESSION';
+    const SESS_KEY = 'WQT_CFG_SESSION';
     const getToken = () => localStorage.getItem(SESS_KEY) || '';
     const setToken = (t) => t ? localStorage.setItem(SESS_KEY, t) : localStorage.removeItem(SESS_KEY);
     const withSession = (payload = {}) => {
@@ -925,7 +925,7 @@
       const u = (document.getElementById('login_user')?.value || '').trim();
       const p = document.getElementById('login_pass')?.value || '';
       if (!u || !p) return alert('Nhập tài khoản và mật khẩu.');
-      runApi('local_login_api', { user: u, password: p }, res => {
+      runApi('config_local_login_api', { user: u, password: p }, res => {
         if (!handleLoginSuccess(res, u)) alert('Đăng nhập thất bại.');
       }, e => alert(e?.message || e));
     }
@@ -946,7 +946,7 @@
 
     function logoutAll(){
       const t = getToken();
-      runApi('local_logout_api', { token: t }, () => {
+      runApi('config_local_logout_api', { token: t }, () => {
         setToken('');
         setAuthState(false);
         showLoginDialog();

--- a/cms_index.html
+++ b/cms_index.html
@@ -56,7 +56,7 @@
           <h2>Tổng quan</h2>
 
           <div id="dashboard_kpis" class="kpi-grid4">
-            <div class="kpi-panel">
+            <div class="kpi-panel" data-kpi="fund">
               <div class="kpi-panel-title">Nguồn vốn</div>
               <div class="kpi-panel-body">
                 <div class="kpi">
@@ -69,7 +69,7 @@
                 </div>
               </div>
             </div>
-            <div class="kpi-panel">
+            <div class="kpi-panel" data-kpi="cashflow">
               <div class="kpi-panel-title">Dòng tiền</div>
               <div class="kpi-panel-body">
                 <div class="kpi">
@@ -90,7 +90,7 @@
                 </div>
               </div>
             </div>
-            <div class="kpi-panel">
+            <div class="kpi-panel" data-kpi="customers">
               <div class="kpi-panel-title">Khách hàng</div>
               <div class="kpi-panel-body">
                 <div class="kpi">
@@ -103,7 +103,7 @@
                 </div>
               </div>
             </div>
-            <div class="kpi-panel">
+            <div class="kpi-panel" data-kpi="loans">
               <div class="kpi-panel-title">Hợp đồng</div>
               <div class="kpi-panel-body">
                 <div class="kpi">
@@ -269,95 +269,93 @@
         <section id="view-loanmgr" class="view hidden">
           <h2>Quản lý khoản vay / Thanh toán</h2>
 
-          <div class="card">
-            <div class="card-head">Phiếu thanh toán (theo kỳ hoặc khoảng ngày)</div>
-            <div class="card-body">
-              <div class="grid-2">
-                <div>
-                  <div class="toolbar">
-                    <input id="slip_mahd" class="input" placeholder="Nhập Mã HĐ" />
-                    <label>Kỳ</label>
-                    <select id="slip_k_select" class="input">
-                      <option value="">(Tự động)</option>
-                    </select>
-                    <button id="slip_btn" class="btn">Xem phiếu (kỳ)</button>
+          <div class="loanmgr-layout">
+            <div class="loanmgr-left">
+              <div class="card loanmgr-slip">
+                <div class="card-head">Phiếu thanh toán</div>
+                <div class="card-body">
+                  <div class="slip-control">
+                    <div class="slip-row">
+                      <input id="slip_mahd" class="input" placeholder="Nhập Mã HĐ" />
+                      <label for="slip_k_select">Kỳ</label>
+                      <select id="slip_k_select" class="input">
+                        <option value="">(Tự động)</option>
+                      </select>
+                      <button id="slip_btn" class="btn">Xem phiếu (kỳ)</button>
+                    </div>
+                    <div class="slip-row">
+                      <label for="slip_from" class="slip-range-label">Theo khoảng ngày</label>
+                      <input id="slip_from" type="date" class="input" />
+                      <span class="slip-range-sep">—</span>
+                      <input id="slip_to" type="date" class="input" />
+                      <button id="slip_btn_range" class="btn">Xem phiếu (khoảng ngày)</button>
+                    </div>
                   </div>
 
-                  <div class="toolbar">
-                    <label>Tính theo khoảng ngày:</label>
-                    <input id="slip_from" type="date" class="input" />
-                    <span>—</span>
-                    <input id="slip_to" type="date" class="input" />
-                    <button id="slip_btn_range" class="btn">Xem phiếu (khoảng ngày)</button>
-                  </div>
-
-                  <div id="slip_card" class="slip card hideable">
-                    <div class="card-head" id="slip_title">Phiếu thanh toán</div>
-                    <div class="card-body">
-                      <div class="grid-2">
-                        <div>
-                          <div><b>Mã HĐ:</b> <span id="slip_id"></span></div>
-                          <div><b>Tên KH:</b> <span id="slip_name"></span></div>
-                          <div><b>Hình thức:</b> <span id="slip_type"></span></div>
-                        </div>
-                        <div>
-                          <div><b>Kỳ:</b> <span id="slip_k"></span></div>
-                          <div><b>Từ:</b> <span id="slip_from_txt"></span></div>
-                          <div><b>Đến:</b> <span id="slip_to_txt"></span></div>
-                        </div>
+                  <div id="slip_card" class="slip-summary hideable">
+                    <div class="slip-summary-head">
+                      <div id="slip_title" class="slip-summary-title">Phiếu thanh toán</div>
+                      <button id="slip_tg_btn" class="btn ghost">Gửi Telegram (ảnh)</button>
+                    </div>
+                    <div class="slip-summary-meta">
+                      <div>
+                        <div><span class="meta-label">Mã HĐ:</span> <span id="slip_id"></span></div>
+                        <div><span class="meta-label">Tên KH:</span> <span id="slip_name"></span></div>
+                        <div><span class="meta-label">Hình thức:</span> <span id="slip_type"></span></div>
                       </div>
-                      <hr />
-                      <div class="grid-3">
-                        <div>
-                          <div>Gốc đến hạn</div>
-                          <div class="num" id="slip_goc_due">0</div>
-                          <div class="muted">Đã thu: <span id="slip_goc_paid">0</span></div>
-                        </div>
-                        <div>
-                          <div>Lãi đến hạn</div>
-                          <div class="num" id="slip_lai_due">0</div>
-                          <div class="muted">Đã thu: <span id="slip_lai_paid">0</span></div>
-                        </div>
-                        <div>
-                          <div>Tổng</div>
-                          <div class="num" id="slip_total_due">0</div>
-                          <div class="muted">Đã thu: <span id="slip_total_paid">0</span></div>
-                        </div>
-                      </div>
-                      <div class="alert info m8">
-                        Còn phải thu: <b id="slip_total_remain">0</b>
+                      <div>
+                        <div><span class="meta-label">Kỳ:</span> <span id="slip_k"></span></div>
+                        <div><span class="meta-label">Từ:</span> <span id="slip_from_txt"></span></div>
+                        <div><span class="meta-label">Đến:</span> <span id="slip_to_txt"></span></div>
                       </div>
                     </div>
-                    <div class="card-foot">
-                      <button id="slip_tg_btn" class="btn">Gửi Telegram (ảnh)</button>
+                    <div class="slip-summary-grid">
+                      <div class="slip-summary-item">
+                        <div class="title">Gốc đến hạn</div>
+                        <div class="value" id="slip_goc_due">0</div>
+                        <div class="muted">Đã thu: <span id="slip_goc_paid">0</span></div>
+                      </div>
+                      <div class="slip-summary-item">
+                        <div class="title">Lãi đến hạn</div>
+                        <div class="value" id="slip_lai_due">0</div>
+                        <div class="muted">Đã thu: <span id="slip_lai_paid">0</span></div>
+                      </div>
+                      <div class="slip-summary-item">
+                        <div class="title">Tổng</div>
+                        <div class="value" id="slip_total_due">0</div>
+                        <div class="muted">Đã thu: <span id="slip_total_paid">0</span></div>
+                      </div>
+                    </div>
+                    <div class="slip-summary-footer">
+                      Còn phải thu: <b id="slip_total_remain">0</b>
                     </div>
                   </div>
                 </div>
+              </div>
+            </div>
 
-                <!-- Lịch kỳ -->
-                <div>
-                  <div class="card">
-                    <div class="card-head">Kỳ sắp tới (12 kỳ)</div>
-                    <div class="card-body">
-                      <table class="tbl">
-                        <thead><tr><th>Kỳ</th><th>Đến hạn</th><th>Gốc</th><th>Lãi</th><th>Tổng</th></tr></thead>
-                        <tbody id="upcoming_rows"></tbody>
-                      </table>
+            <div class="loanmgr-right">
+              <div class="card upcoming-card">
+                <div class="card-head">Kỳ sắp tới (12 kỳ)</div>
+                <div class="card-body">
+                  <table class="tbl">
+                    <thead><tr><th>Kỳ</th><th>Đến hạn</th><th>Gốc</th><th>Lãi</th><th>Tổng</th></tr></thead>
+                    <tbody id="upcoming_rows"></tbody>
+                  </table>
+                </div>
+              </div>
+
+              <div class="card pay-card">
+                <div class="card-head">Thanh toán</div>
+                <div class="card-body">
+                  <div class="row">
+                    <div class="col-6">
+                      <input id="pay_id" class="input" placeholder="PaymentID (để sửa/xoá)" />
+                    </div>
+                    <div class="col-6">
+                      <input id="pay_loan" class="input" placeholder="Mã HĐ" />
                     </div>
                   </div>
-
-                  <!-- Payment form -->
-                  <div class="card">
-                    <div class="card-head">Thanh toán</div>
-                    <div class="card-body">
-                      <div class="row">
-                        <div class="col-6">
-                          <input id="pay_id" class="input" placeholder="PaymentID (để sửa/xoá)" />
-                        </div>
-                        <div class="col-6">
-                          <input id="pay_loan" class="input" placeholder="Mã HĐ" />
-                        </div>
-                      </div>
                       <div class="row">
                         <div class="col-4 field">
                           <label for="pay_date">Ngày</label>
@@ -614,6 +612,11 @@
                   <input id="cfg_show_kpi" type="checkbox" />
                   <span>Hiển thị KPI trên trang Tổng quan</span>
                 </label>
+              </div>
+              <div class="kpi-config-wrap">
+                <div class="sub-title">KPI hiển thị</div>
+                <div class="muted">Bật/tắt từng KPI và dùng mũi tên để sắp xếp thứ tự hiển thị ở trang Tổng quan.</div>
+                <div id="kpi_config_list" class="kpi-config-list"></div>
               </div>
             </div>
             <div class="card-foot">

--- a/cms_scripts.html
+++ b/cms_scripts.html
@@ -19,6 +19,14 @@ const MENU = RAW_MENU.map(m => ({
   icon: m.icon || '' // để dành nếu sau này muốn hiện biểu tượng
 }));
 
+const KPI_DEFS = [
+  { key:'fund',      label:'Nguồn vốn' },
+  { key:'cashflow',  label:'Dòng tiền' },
+  { key:'customers', label:'Khách hàng' },
+  { key:'loans',     label:'Hợp đồng' }
+];
+const KPI_DEFAULT_ORDER = KPI_DEFS.map(k => k.key);
+
 const AUTH_STATE = { ok:false, principal:'', mode:'' };
 
 function setAuthState(ok, meta){
@@ -208,14 +216,55 @@ function renderTableRows(tbody, rows, fallbackCols){
 }
 
 /* ========= DASHBOARD ========= */
+function normalizeKpiLayoutClient(layout){
+  const orderIn = Array.isArray(layout?.order) ? layout.order.filter(key => KPI_DEFAULT_ORDER.includes(key)) : [];
+  KPI_DEFAULT_ORDER.forEach(key => { if (!orderIn.includes(key)) orderIn.push(key); });
+  const hiddenIn = Array.isArray(layout?.hidden) ? layout.hidden.filter(key => KPI_DEFAULT_ORDER.includes(key)) : [];
+  return { order: orderIn, hidden: hiddenIn };
+}
+
+function applyDashboardKpiLayout(cfg){
+  const wrap = document.getElementById('dashboard_kpis');
+  const info = document.getElementById('dashboard_kpis_hidden');
+  const layout = normalizeKpiLayoutClient(cfg?.dashboardKpiConfig || {});
+  const showAll = cfg?.showDashboardKpis !== false;
+  if (wrap){
+    const panels = Array.from(wrap.querySelectorAll('[data-kpi]'));
+    const map = new Map(panels.map(panel => [panel.dataset.kpi, panel]));
+    layout.order.forEach(key => {
+      const panel = map.get(key);
+      if (panel) wrap.appendChild(panel);
+    });
+    const hiddenSet = new Set(layout.hidden);
+    let visibleCount = 0;
+    panels.forEach(panel => {
+      const hide = !showAll || hiddenSet.has(panel.dataset.kpi);
+      panel.classList.toggle('hidden', hide);
+      if (!hide) visibleCount++;
+    });
+    const shouldShow = showAll && visibleCount > 0;
+    wrap.classList.toggle('hidden', !shouldShow);
+    if (info){
+      info.textContent = showAll
+        ? 'Không có KPI nào được bật. Vào tab Cấu hình để hiển thị.'
+        : 'KPI đang tắt. Vào tab Cấu hình để bật hiển thị.';
+      info.classList.toggle('hidden', shouldShow);
+    }
+    return shouldShow;
+  }
+  if (info){
+    info.textContent = showAll
+      ? 'Không có KPI nào được bật. Vào tab Cấu hình để hiển thị.'
+      : 'KPI đang tắt. Vào tab Cấu hình để bật hiển thị.';
+    info.classList.toggle('hidden', showAll);
+  }
+  return showAll;
+}
+
 function loadDashboard(){
   runApi('getAppConfig', {}, cfg=>{
-    const show = cfg?.showDashboardKpis !== false;
-    const wrap = document.getElementById('dashboard_kpis');
-    const info = document.getElementById('dashboard_kpis_hidden');
-    if (wrap) wrap.classList.toggle('hidden', !show);
-    if (info) info.classList.toggle('hidden', show);
-    if (show){
+    const shouldLoad = applyDashboardKpiLayout(cfg);
+    if (shouldLoad){
       runApi('getDashboardKpis_api', {}, data=>{
         if (!data) return;
         const setText = (id, val) => { const el=document.getElementById(id); if(el) el.textContent=val; };
@@ -770,6 +819,68 @@ function loadPayHistory(){
 }
 
 /* ========= SETTINGS ========= */
+function bindKpiConfigActions(){
+  const wrap = document.getElementById('kpi_config_list');
+  if (!wrap || wrap.dataset.bound) return;
+  wrap.dataset.bound = '1';
+  wrap.addEventListener('click', ev => {
+    const btn = ev.target.closest('button[data-dir]');
+    if (!btn) return;
+    const item = btn.closest('.kpi-config-item');
+    if (!item || !item.parentElement) return;
+    if (btn.dataset.dir === 'up'){
+      const prev = item.previousElementSibling;
+      if (prev) item.parentElement.insertBefore(item, prev);
+    } else if (btn.dataset.dir === 'down'){
+      const next = item.nextElementSibling;
+      if (next) item.parentElement.insertBefore(next, item);
+    }
+  });
+}
+
+function renderKpiConfigList(cfg){
+  const wrap = document.getElementById('kpi_config_list');
+  if (!wrap) return;
+  const layout = normalizeKpiLayoutClient(cfg?.dashboardKpiConfig || {});
+  wrap.innerHTML = '';
+  layout.order.forEach(key => {
+    const def = KPI_DEFS.find(d => d.key === key) || { label: key };
+    const row = document.createElement('div');
+    row.className = 'kpi-config-item';
+    row.dataset.key = key;
+    const label = document.createElement('label');
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.checked = layout.hidden.indexOf(key) === -1;
+    label.appendChild(checkbox);
+    label.appendChild(document.createTextNode(def.label));
+    const actions = document.createElement('div');
+    actions.className = 'kpi-config-actions';
+    const up = document.createElement('button'); up.type = 'button'; up.dataset.dir = 'up'; up.textContent = '↑';
+    const down = document.createElement('button'); down.type = 'button'; down.dataset.dir = 'down'; down.textContent = '↓';
+    actions.appendChild(up); actions.appendChild(down);
+    row.appendChild(label);
+    row.appendChild(actions);
+    wrap.appendChild(row);
+  });
+  bindKpiConfigActions();
+}
+
+function collectKpiConfig(){
+  const wrap = document.getElementById('kpi_config_list');
+  const items = Array.from(wrap?.querySelectorAll('.kpi-config-item') || []);
+  const order = [];
+  const hidden = [];
+  items.forEach(item => {
+    const key = item.dataset.key;
+    if (!key) return;
+    order.push(key);
+    const checked = item.querySelector('input[type="checkbox"]')?.checked !== false;
+    if (!checked) hidden.push(key);
+  });
+  return normalizeKpiLayoutClient({ order, hidden });
+}
+
 function loadSettings(){
   runApi('getAppConfig', {}, cfg=>{
     const el = document.getElementById('cfg_fund');
@@ -778,6 +889,7 @@ function loadSettings(){
     if (elPT) elPT.value = (cfg?.payTypes || ['gốc','lãi','phí']).join(',');
     const chk = document.getElementById('cfg_show_kpi');
     if (chk) chk.checked = cfg?.showDashboardKpis !== false;
+    renderKpiConfigList(cfg);
     refreshPayTypeOptions(cfg?.payTypes || ['gốc','lãi','phí']);
   });
 }
@@ -786,7 +898,8 @@ function saveSettings(){
   const payTypes = (document.getElementById('cfg_paytypes')?.value || 'gốc,lãi,phí')
                    .split(',').map(s=>s.trim()).filter(Boolean);
   const showDashboardKpis = document.getElementById('cfg_show_kpi')?.checked ?? true;
-  runApi('setAppConfig', { fund, payTypes, showDashboardKpis }, _=>{
+  const dashboardKpiConfig = collectKpiConfig();
+  runApi('setAppConfig', { fund, payTypes, showDashboardKpis, dashboardKpiConfig }, _=>{
     alert('Đã lưu cấu hình.');
     loadDashboard();
     refreshPayTypeOptions(payTypes);

--- a/cms_styles.html
+++ b/cms_styles.html
@@ -29,6 +29,7 @@
   }
   img{ max-width:100%; }
   .hidden{ display:none !important; }
+  .hideable{ display:none; }
   .muted{ color:var(--muted); }
   .num{ text-align:right; }
   .m8{ margin-top:8px; }
@@ -383,6 +384,12 @@
     cursor:pointer;
     transition:.15s ease;
   }
+  .btn.ghost{
+    background:#fff;
+    border-color:var(--border);
+    color:#111827;
+  }
+  .btn.ghost:hover{ background:#f8fafc; }
   .btn:hover{ transform:translateY(-1px); }
   .btn.primary{ background:var(--pri); border-color:var(--pri); color:#fff; }
   .btn.primary:hover{ background:var(--pri-600); }
@@ -418,6 +425,73 @@
   input:focus, select:focus, textarea:focus{
     border-color:#c7cbe0; box-shadow:0 0 0 3px rgba(79,70,229,.12);
   }
+
+  /* ================== LOAN MANAGER ================== */
+  .loanmgr-layout{
+    display:grid;
+    grid-template-columns:minmax(0,1fr) minmax(280px, 360px);
+    gap:16px;
+  }
+  .loanmgr-left,
+  .loanmgr-right{ display:flex; flex-direction:column; gap:16px; }
+  .slip-control{ display:flex; flex-direction:column; gap:12px; margin-bottom:16px; }
+  .slip-row{ display:flex; flex-wrap:wrap; align-items:center; gap:8px; }
+  .slip-row label{ font-size:13px; font-weight:600; color:var(--muted); }
+  .slip-row .input{ min-width:140px; }
+  .slip-range-label{ min-width:140px; }
+  .slip-range-sep{ font-weight:600; }
+  .slip-summary{
+    border:1px solid var(--border);
+    border-radius:var(--radius);
+    background:#f8fafc;
+    padding:16px;
+    display:flex;
+    flex-direction:column;
+    gap:16px;
+    box-shadow:0 8px 20px rgba(15,23,42,0.08);
+  }
+  .slip-summary-head{ display:flex; justify-content:space-between; align-items:center; gap:12px; }
+  .slip-summary-title{ font-weight:700; font-size:16px; }
+  .slip-summary-meta{
+    display:grid;
+    grid-template-columns:repeat(auto-fit, minmax(180px, 1fr));
+    gap:12px;
+    font-size:13px;
+  }
+  .slip-summary-meta .meta-label{ color:var(--muted); font-weight:600; margin-right:4px; display:inline-block; min-width:72px; }
+  .slip-summary-grid{
+    display:grid;
+    grid-template-columns:repeat(auto-fit, minmax(150px,1fr));
+    gap:12px;
+  }
+  .slip-summary-item{ padding:12px; border-radius:var(--radius-sm); background:#fff; border:1px solid rgba(79,70,229,.12); }
+  .slip-summary-item .title{ font-size:13px; font-weight:600; color:#1f2937; }
+  .slip-summary-item .value{ font-size:20px; font-weight:700; text-align:right; margin-top:6px; }
+  .slip-summary-footer{
+    background:#eef2ff;
+    border-radius:var(--radius-sm);
+    padding:12px 16px;
+    font-weight:600;
+    color:#312e81;
+  }
+
+  /* ================== KPI CONFIG ================== */
+  .kpi-config-wrap{ margin-top:16px; }
+  .kpi-config-list{ display:flex; flex-direction:column; gap:8px; margin-top:8px; }
+  .kpi-config-item{ display:flex; align-items:center; justify-content:space-between; gap:12px; padding:10px 12px; border:1px solid var(--border); border-radius:var(--radius-sm); background:#fff; }
+  .kpi-config-item label{ display:flex; align-items:center; gap:8px; font-weight:600; color:#1f2937; }
+  .kpi-config-item input[type="checkbox"]{ width:auto; height:auto; }
+  .kpi-config-actions{ display:flex; gap:6px; }
+  .kpi-config-actions button{
+    width:32px; height:32px;
+    border-radius:8px;
+    border:1px solid var(--border);
+    background:#f3f4f6;
+    cursor:pointer;
+    font-size:14px;
+    line-height:1;
+  }
+  .kpi-config-actions button:hover{ background:#e5e7eb; }
 
   /* ================== MODAL ================== */
   dialog.modal,
@@ -481,6 +555,10 @@
   .tg-stack{ display:flex; flex-direction:column; gap:16px; }
 
   /* ================== RESPONSIVE ================== */
+  @media (max-width: 1024px){
+    .loanmgr-layout{ grid-template-columns:1fr; }
+    .slip-summary{ order:2; }
+  }
   @media (max-width: 1100px){
     .app{ grid-template-columns: 200px 1fr; }
     .kpi-grid{ grid-template-columns: repeat(2, minmax(0,1fr)); }


### PR DESCRIPTION
## Summary
- add a dedicated CONFIG_ACCOUNTS sheet with login/logout APIs and session handling for the configuration admin portal
- rework the loan management layout and styling for clearer slip and upcoming schedule presentation
- expose dashboard KPI visibility and ordering controls in settings with backend persistence and frontend application

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0a517ac7483298545e86f6a0b2104