### PR TITLE
Fix config login and normalize numeric parsing

### DIFF
--- a/cms_scripts.html
+++ b/cms_scripts.html
@@ -157,7 +157,46 @@ function applyMenuVisibility(){
 
 /* ========= Helpers ========= */
 const money = n => Number(n||0).toLocaleString('vi-VN');
-function toNum(s){ return Number(String(s??'').replace(/[^\d\-]/g,'')) || 0; }
+function toNum(v){
+  if (v === null || v === undefined) return 0;
+  if (typeof v === 'number') return Number.isNaN(v) ? 0 : v;
+  let s = String(v).trim();
+  if (!s) return 0;
+  s = s.replace(/[\s\u00A0]+/g, '');
+  let negative = false;
+  if (s.startsWith('-')){ negative = true; s = s.slice(1); }
+  s = s.replace(/[^0-9,\.]/g, '');
+
+  const commaCount = (s.match(/,/g) || []).length;
+  const dotCount   = (s.match(/\./g) || []).length;
+
+  if (commaCount && dotCount){
+    if (s.lastIndexOf(',') > s.lastIndexOf('.')){
+      s = s.replace(/\./g, '');
+      s = s.replace(/,/g, '.');
+    } else {
+      s = s.replace(/,/g, '');
+    }
+  } else if (commaCount){
+    if (commaCount === 1 && s.split(',')[1] && s.split(',')[1].length <= 2){
+      s = s.replace(',', '.');
+    } else {
+      s = s.replace(/,/g, '');
+    }
+  } else if (dotCount){
+    if (dotCount === 1 && s.split('.')[1] && s.split('.')[1].length <= 2){
+      // giữ lại dấu . làm phần thập phân
+    } else {
+      s = s.replace(/\./g, '');
+    }
+  }
+
+  s = s.replace(/[^0-9\.]/g, '');
+  if (!s) return 0;
+  const out = Number(s);
+  if (Number.isNaN(out)) return 0;
+  return negative ? -out : out;
+}
 function fmt(v){
   if (!v) return '';
   const d=new Date(v);

--- a/cms_styles.html
+++ b/cms_styles.html
@@ -68,9 +68,10 @@
     display:flex;
     flex-direction:column;
     gap:16px;
-    align-items:center;
+    align-items:stretch;
     padding-bottom:32px;
   }
+  .content > .view{ margin:0 auto; }
 
   .login-blocker{
     position:fixed;


### PR DESCRIPTION
## Summary
- normalize numeric parsing on both backend and frontend helpers so Vietnamese-formatted loan amounts populate KPIs and schedules correctly
- allow the configuration admin login flow to reuse active CMS accounts (with schema/account permissions) while keeping menu restrictions
- adjust the content layout so main views stay centered without being pushed downward across tabs

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e0bd1ab0888329857ef13720fa0d11