### PR TITLE
Fix shared auth token and loans layout

### DIFF
--- a/Codex
+++ b/Codex
@@ -1,0 +1,3 @@
+Auth: Thống nhất 1 localStorage key + 1 schema trả về từ /login + có user admin/allowed email.
+Layout: Bù khoảng cho header và chỉ bật 1 view active; bỏ min-height/margin dư.
+Table: Bọc bảng trong wrapper có cuộn, cố định layout bảng, rút gọn/cho ngắt chữ ở cột dài, ẩn bớt cột phụ trên màn nhỏ.

--- a/admin.html
+++ b/admin.html
@@ -471,7 +471,7 @@
     let ACCOUNTS = [];
     let selectedAccount = null;
 
-    const AUTH_STATE = { ok: false, principal: '', info: {} };
+    const AUTH_STATE = { ok: false, principal: '', info: {}, mode: '' };
 
     document.addEventListener('DOMContentLoaded', () => {
       bindMenu();
@@ -549,9 +549,11 @@
     }
 
     function setAuthState(ok, meta){
+      const prev = { ok: AUTH_STATE.ok, principal: AUTH_STATE.principal, mode: AUTH_STATE.mode };
       AUTH_STATE.ok = !!ok;
       AUTH_STATE.info = ok ? (meta || {}) : {};
       AUTH_STATE.principal = ok ? (meta?.display || meta?.principal || '') : '';
+      AUTH_STATE.mode = ok ? (meta?.mode || (meta?.menus ? 'local' : '')) : '';
 
       const status = document.getElementById('auth_status');
       if (status){
@@ -572,6 +574,17 @@
       } else {
         resetSchemaUI();
         resetAccountUI();
+      }
+
+      const changed = prev.ok !== AUTH_STATE.ok || prev.principal !== AUTH_STATE.principal || prev.mode !== AUTH_STATE.mode;
+      if (changed){
+        window.dispatchEvent(new CustomEvent(AUTH_EVENT_NAME, {
+          detail: {
+            ok: AUTH_STATE.ok,
+            mode: AUTH_STATE.mode,
+            principal: AUTH_STATE.principal
+          }
+        }));
       }
     }
 
@@ -855,9 +868,19 @@
       }, showErr);
     }
 
-    const SESS_KEY = 'WQT_CFG_SESSION';
-    const getToken = () => localStorage.getItem(SESS_KEY) || '';
-    const setToken = (t) => t ? localStorage.setItem(SESS_KEY, t) : localStorage.removeItem(SESS_KEY);
+    const SESSION_STORAGE_KEY = 'WQT_TOKEN';
+    const SESSION_EVENT_NAME = 'wqt:session-change';
+    const AUTH_EVENT_NAME = 'wqt:auth-change';
+    const getToken = () => localStorage.getItem(SESSION_STORAGE_KEY) || '';
+    const setToken = (t) => {
+      const token = t ? String(t) : '';
+      if (token){
+        localStorage.setItem(SESSION_STORAGE_KEY, token);
+      } else {
+        localStorage.removeItem(SESSION_STORAGE_KEY);
+      }
+      window.dispatchEvent(new CustomEvent(SESSION_EVENT_NAME, { detail: { token } }));
+    };
     const withSession = (payload = {}) => {
       const out = Object.assign({}, payload || {});
       const t = getToken();

--- a/cms_index.html
+++ b/cms_index.html
@@ -67,7 +67,7 @@
 
       <main class="content">
         <!-- ========== DASHBOARD ========== -->
-        <section id="view-dashboard" class="view">
+        <section id="view-dashboard" class="view view-active">
           <h2>Tổng quan</h2>
 
           <div id="dashboard_kpis" class="kpi-grid4">
@@ -269,15 +269,35 @@
             <button id="btn_new_loan" class="btn primary">Thêm HĐ</button>
           </div>
 
-          <div id="loan_total" class="muted m8">—</div>
-          <table class="tbl">
-            <thead><tr>
-              <th>Mã HĐ</th><th>ID KH</th><th>Tên KH</th><th>PL KH</th><th>Hình thức</th>
-              <th>Giải ngân</th><th>Kỳ hạn</th><th>Lãi %/th</th><th>Số tiền</th><th>Chu kỳ</th>
-              <th>Tất toán</th><th>Trạng thái</th><th>Tạo</th><th>Cập nhật</th><th>Người sửa</th><th>Thao tác</th>
-            </tr></thead>
-            <tbody id="loan_rows"></tbody>
-          </table>
+          <div class="card table-card">
+            <div class="table-card-head">
+              <div class="card-head">Danh sách Hợp đồng</div>
+              <div id="loan_total" class="table-meta muted">—</div>
+            </div>
+            <div class="table-scroll">
+              <table class="tbl tbl-loans">
+                <thead><tr>
+                  <th class="col-code">Mã HĐ</th>
+                  <th class="col-cus-id">ID KH</th>
+                  <th class="col-name">Tên KH</th>
+                  <th class="col-seg">PL KH</th>
+                  <th class="col-type">Hình thức</th>
+                  <th class="col-date">Giải ngân</th>
+                  <th class="col-small">Kỳ hạn</th>
+                  <th class="col-small">Lãi %/th</th>
+                  <th class="col-amount">Số tiền</th>
+                  <th class="col-small">Chu kỳ</th>
+                  <th class="col-date">Tất toán</th>
+                  <th class="col-status">Trạng thái</th>
+                  <th class="col-date">Tạo</th>
+                  <th class="col-date optional">Cập nhật</th>
+                  <th class="col-editor optional">Người sửa</th>
+                  <th class="col-actions">Thao tác</th>
+                </tr></thead>
+                <tbody id="loan_rows"></tbody>
+              </table>
+            </div>
+          </div>
         </section>
 
         <!-- ========== LOAN MANAGER / PAYMENTS ========== -->

--- a/cms_scripts.html
+++ b/cms_scripts.html
@@ -27,12 +27,18 @@ const KPI_DEFS = [
 ];
 const KPI_DEFAULT_ORDER = KPI_DEFS.map(k => k.key);
 
-const AUTH_STATE = { ok:false, principal:'', mode:'' };
+const SESSION_STORAGE_KEY = 'WQT_TOKEN';
+const SESSION_EVENT_NAME = 'wqt:session-change';
+const AUTH_EVENT_NAME = 'wqt:auth-change';
+
+const AUTH_STATE = { ok:false, principal:'', mode:'', display:'' };
 
 function setAuthState(ok, meta){
+  const prev = { ok: AUTH_STATE.ok, principal: AUTH_STATE.principal, mode: AUTH_STATE.mode };
   AUTH_STATE.ok = !!ok;
   AUTH_STATE.mode = ok ? (meta?.mode || (meta?.menus ? 'local' : '')) : '';
   AUTH_STATE.principal = ok ? (meta?.display || meta?.principal || '') : '';
+  AUTH_STATE.display = AUTH_STATE.principal;
 
   const blocker = document.getElementById('login_blocker');
   if (blocker) blocker.classList.toggle('hidden', AUTH_STATE.ok);
@@ -55,6 +61,17 @@ function setAuthState(ok, meta){
 
   if (!AUTH_STATE.ok) {
     showLoginDialog();
+  }
+
+  const changed = prev.ok !== AUTH_STATE.ok || prev.principal !== AUTH_STATE.principal || prev.mode !== AUTH_STATE.mode;
+  if (changed){
+    window.dispatchEvent(new CustomEvent(AUTH_EVENT_NAME, {
+      detail: {
+        ok: AUTH_STATE.ok,
+        mode: AUTH_STATE.mode,
+        principal: AUTH_STATE.principal
+      }
+    }));
   }
 }
 
@@ -125,10 +142,16 @@ function setActiveTab(key){
 }
 function onRoute(){
   const key = currentKey();
-  const keys = MENU.map(m => m.key); // LẤY TỰ ĐỘNG
-  keys.forEach(k => {
-    const el = document.getElementById('view-' + k);
-    if (el) el.classList.toggle('hidden', k !== key);
+  const keys = MENU.map(m => m.key);
+  if (keys.length && !keys.includes(key)){
+    navigate(keys[0]);
+    return;
+  }
+  document.querySelectorAll('.view').forEach(el => {
+    const viewKey = (el.id || '').replace('view-', '');
+    const isActive = viewKey === key;
+    el.classList.toggle('hidden', !isActive);
+    el.classList.toggle('view-active', isActive);
   });
   setActiveTab(key);
   if (!AUTH_STATE.ok) return;
@@ -514,22 +537,47 @@ function loadLoans(page=1){
       rows.forEach(r=>{
         const id = pick(r,idIdx);
         const tr=document.createElement('tr');
-        [
-          id, pick(r,cusIdIdx), pick(r,cusNameIdx), pick(r,plIdx), pick(r,typeIdx),
-          fmt(pick(r,startIdx)), pick(r,monthsIdx), pick(r,rateIdx),
-          pick(r,amountIdx), pick(r,cycleIdx), fmt(pick(r,closeIdx)),
-          pick(r,statusIdx), fmt(pick(r,cIdx)), fmt(pick(r,uIdx)), pick(r,eIdx)
-        ].forEach(v=>{ const td=document.createElement('td'); td.textContent=(v??''); tr.appendChild(td); });
+        const amountRaw = pick(r,amountIdx);
+        const amountTxt = (amountRaw === undefined || amountRaw === null || amountRaw === '')
+          ? ''
+          : money(toNum(amountRaw));
+        const cells = [
+          { value:id, cls:'col-code' },
+          { value:pick(r,cusIdIdx), cls:'col-cus-id' },
+          { value:pick(r,cusNameIdx), cls:'col-name' },
+          { value:pick(r,plIdx), cls:'col-seg' },
+          { value:pick(r,typeIdx), cls:'col-type' },
+          { value:fmt(pick(r,startIdx)), cls:'col-date' },
+          { value:pick(r,monthsIdx), cls:'col-small' },
+          { value:pick(r,rateIdx), cls:'col-small' },
+          { value:amountTxt, cls:'col-amount num' },
+          { value:pick(r,cycleIdx), cls:'col-small' },
+          { value:fmt(pick(r,closeIdx)), cls:'col-date' },
+          { value:pick(r,statusIdx), cls:'col-status' },
+          { value:fmt(pick(r,cIdx)), cls:'col-date' },
+          { value:fmt(pick(r,uIdx)), cls:'col-date optional' },
+          { value:pick(r,eIdx), cls:'col-editor optional' }
+        ];
+        cells.forEach(cell=>{
+          const td=document.createElement('td');
+          if (cell.cls) td.className = cell.cls;
+          td.textContent = (cell.value ?? '');
+          tr.appendChild(td);
+        });
 
         // Thao tác
         const tdAct=document.createElement('td');
+        tdAct.className='col-actions';
+        const group=document.createElement('div');
+        group.className='action-group';
         const bView=document.createElement('button'); bView.className='btn'; bView.textContent='Xem';
         bView.onclick=()=>{ document.getElementById('slip_mahd').value=id; navigate('loanmgr'); showLoanSlip(); };
-        const bEdit=document.createElement('button'); bEdit.className='btn'; bEdit.textContent='Sửa'; bEdit.style.marginLeft='6px';
+        const bEdit=document.createElement('button'); bEdit.className='btn'; bEdit.textContent='Sửa';
         bEdit.onclick=()=> openEditLoanDialog(r, H);
-        const bDel=document.createElement('button'); bDel.className='btn danger'; bDel.textContent='Xoá'; bDel.style.marginLeft='6px';
+        const bDel=document.createElement('button'); bDel.className='btn danger'; bDel.textContent='Xoá';
         bDel.onclick=()=> deleteLoanById(id);
-        tdAct.appendChild(bView); tdAct.appendChild(bEdit); tdAct.appendChild(bDel);
+        group.appendChild(bView); group.appendChild(bEdit); group.appendChild(bDel);
+        tdAct.appendChild(group);
         tr.appendChild(tdAct);
 
         tb.appendChild(tr);
@@ -1059,9 +1107,16 @@ window.addEventListener('DOMContentLoaded', ()=>{
 });
 
 // ===== Session token (tài khoản nội bộ) =====
-const SESS_KEY = 'WQT_SESSION';
-const getToken = () => localStorage.getItem(SESS_KEY) || '';
-const setToken = (t) => t ? localStorage.setItem(SESS_KEY, t) : localStorage.removeItem(SESS_KEY);
+const getToken = () => localStorage.getItem(SESSION_STORAGE_KEY) || '';
+const setToken = (t) => {
+  const token = t ? String(t) : '';
+  if (token){
+    localStorage.setItem(SESSION_STORAGE_KEY, token);
+  } else {
+    localStorage.removeItem(SESSION_STORAGE_KEY);
+  }
+  window.dispatchEvent(new CustomEvent(SESSION_EVENT_NAME, { detail: { token } }));
+};
 const withSession = (payload={}) => {
   const out = Object.assign({}, payload || {});
   const t = getToken();

--- a/cms_styles.html
+++ b/cms_styles.html
@@ -21,6 +21,7 @@
   html,body{ height:100%; }
   body{
     margin:0;
+    padding-top:56px;
     background:var(--bg);
     color:var(--text);
     font:14px/1.55 ui-sans-serif, system-ui, -apple-system, "Segoe UI", Inter, Roboto, Arial;
@@ -40,11 +41,12 @@
 
   /* ================== LAYOUT (TOPBAR + SIDEBAR + MAIN) ================== */
   .topbar{
-    position:sticky; top:0; z-index:50;
+    position:fixed; top:0; left:0; right:0; z-index:120;
     display:flex; align-items:center; gap:12px;
     height:56px; padding:0 16px;
     background:var(--surface);
     border-bottom:1px solid var(--border);
+    box-shadow:0 8px 24px rgba(15,23,42,0.06);
   }
   .brand{ font-weight:700; letter-spacing:.2px; }
   .auth-status{
@@ -80,7 +82,7 @@
     display:flex;
     align-items:center;
     justify-content:center;
-    z-index:120;
+    z-index:200;
     padding:24px;
   }
   body.needs-login .app > :not(#login_blocker){ pointer-events:none; }
@@ -166,6 +168,7 @@
     min-width:0;
   }
   .view{
+    display:none;
     padding:16px;
     background:var(--surface);
     border:1px solid var(--border);
@@ -173,9 +176,11 @@
     box-shadow:var(--shadow);
     width:100%;
     max-width:1280px;
-    display:flex;
     flex-direction:column;
     gap:16px;
+  }
+  .view.view-active{
+    display:flex;
   }
   h2{
     margin:0 0 12px 0;
@@ -404,6 +409,30 @@
   .tbl .status-ok{ color:var(--ok); font-weight:600; }
   .tbl .status-warn{ color:var(--warn); font-weight:600; }
   .tbl .status-danger{ color:var(--danger); font-weight:700; }
+  .table-card{ padding:0; display:flex; flex-direction:column; overflow:hidden; }
+  .table-card-head{ display:flex; align-items:center; justify-content:space-between; gap:12px; padding:16px; border-bottom:1px solid var(--border); flex-wrap:wrap; }
+  .table-card-head .table-meta{ margin-left:auto; }
+  .table-meta{ font-size:13px; }
+  .table-scroll{ width:100%; overflow-x:auto; }
+  .tbl-loans{ table-layout:fixed; min-width:1100px; }
+  .tbl-loans th, .tbl-loans td{ vertical-align:middle; }
+  .tbl-loans .col-code{ width:120px; }
+  .tbl-loans .col-cus-id{ width:120px; }
+  .tbl-loans .col-name{ min-width:200px; max-width:260px; }
+  .tbl-loans .col-seg{ max-width:140px; }
+  .tbl-loans .col-type{ max-width:160px; }
+  .tbl-loans .col-date{ width:140px; }
+  .tbl-loans .col-small{ width:96px; }
+  .tbl-loans .col-amount{ width:140px; }
+  .tbl-loans .col-status{ max-width:140px; }
+  .tbl-loans .col-editor{ max-width:220px; white-space:normal; overflow-wrap:anywhere; }
+  .tbl-loans .col-actions{ width:180px; }
+  .action-group{ display:inline-flex; gap:6px; flex-wrap:nowrap; }
+  .action-group .btn{ flex:1 0 auto; white-space:nowrap; }
+  @media (max-width: 1280px){
+    .tbl-loans th.optional,
+    .tbl-loans td.optional{ display:none; }
+  }
 
   /* ================== BUTTONS ================== */
   .btn{


### PR DESCRIPTION
## Summary
- use a single `WQT_TOKEN` key for storing the session token on both the CMS and configuration pages and emit session/auth change events after login state updates
- pin the header, adjust view visibility handling, and add styling helpers so only the active section is rendered without layout jumps
- wrap the loans table in a scrollable card, constrain column widths, and format long values to keep the grid inside its container

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0db47853c832988bc9c0b99b368f1