### PR TITLE
Adjust admin views to use full width layout

### DIFF
--- a/cms_scripts.html
+++ b/cms_scripts.html
@@ -524,7 +524,13 @@ function loadLoans(page=1){
       const statusIdx = (H['Trạng thái'] ?? H['Status'] ?? -1);
       const cIdx      = (H['Tạo'] ?? H['CreatedAt'] ?? -1);
       const uIdx      = (H['Cập nhật'] ?? H['UpdatedAt'] ?? -1);
-      const eIdx      = (H['Người sửa'] ?? H['UpdatedBy'] ?? -1);
+      const eIdx      = (
+        H['Người sửa'] ??
+        H['UpdatedBy'] ??
+        H['UpdatedByEmail'] ??
+        H['UpdatedByName'] ??
+        -1
+      );
 
       const tb=document.getElementById('loan_rows'); if(!tb) return;
       tb.innerHTML='';

--- a/cms_styles.html
+++ b/cms_styles.html
@@ -61,9 +61,11 @@
 
   .app{
     display:grid;
-    grid-template-columns: 240px 1fr;
+    grid-template-columns: 240px minmax(0, 1fr);
     gap:16px;
-    padding:16px;
+    padding:0 16px 32px;
+    width:100%;
+    align-items:flex-start;
   }
 
   .content{
@@ -72,8 +74,9 @@
     gap:16px;
     align-items:stretch;
     padding-bottom:32px;
+    width:100%;
+    min-width:0;
   }
-  .content > .view{ margin:0 auto; }
 
   .login-blocker{
     position:fixed;
@@ -132,8 +135,8 @@
     flex-direction:column;
     gap:6px;
     position:sticky;
-    top:72px;
-    max-height:calc(100vh - 88px);
+    top:56px;
+    max-height:calc(100vh - 72px);
     overflow:auto;
   }
   .tabbtn{
@@ -175,7 +178,8 @@
     border-radius:var(--radius);
     box-shadow:var(--shadow);
     width:100%;
-    max-width:1280px;
+    max-width:none;
+    min-width:0;
     flex-direction:column;
     gap:16px;
   }
@@ -410,7 +414,7 @@
   .tbl .status-warn{ color:var(--warn); font-weight:600; }
   .tbl .status-danger{ color:var(--danger); font-weight:700; }
   .table-card{ padding:0; display:flex; flex-direction:column; overflow:hidden; }
-  .table-card-head{ display:flex; align-items:center; justify-content:space-between; gap:12px; padding:16px; border-bottom:1px solid var(--border); flex-wrap:wrap; }
+  .table-card-head{ display:flex; align-items:center; justify-content:space-between; gap:12px; padding:12px 16px; border-bottom:1px solid var(--border); flex-wrap:wrap; }
   .table-card-head .table-meta{ margin-left:auto; }
   .table-meta{ font-size:13px; }
   .table-scroll{ width:100%; overflow-x:auto; }


### PR DESCRIPTION
## Summary
- expand the main app grid so every view stretches across the content area while keeping the sidebar fixed and aligned with the topbar
- reduce the loan list card header padding to tighten the section while preserving overflow handling for the expanded table
- expose the latest editor information in the loan table by reading multiple metadata fields for the "Người sửa" column

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e0e986e3f4832992865b1ee43e0fb5