### PR TITLE
Ensure login overlay spans full grid

### DIFF
--- a/cms_styles.html
+++ b/cms_styles.html
@@ -98,6 +98,10 @@
     z-index:200;
     padding:24px;
   }
+  #login_blocker{
+    grid-column:1 / -1;
+    grid-row:1;
+  }
   body.needs-login .app > :not(#login_blocker){ pointer-events:none; }
   .login-blocker.hidden{ display:none !important; }
   .login-blocker-card{


### PR DESCRIPTION
## Summary
- ensure the login blocker grid item spans the full layout width so it no longer collapses into the sidebar column

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e380cca38c8329ae7bc140cf388c28